### PR TITLE
Display correct file download progress

### DIFF
--- a/src/Command/DownloadCommand.php
+++ b/src/Command/DownloadCommand.php
@@ -289,10 +289,10 @@ final class DownloadCommand extends Command
                             $progress->setProgress(0);
                             $progress->setMessage("{$download->name} ({$download->platform}, {$download->language})");
 
-                            $responses = $this->downloadManager->download($download, function (int $current, int $total) use ($progress, $output) {
+                            $responses = $this->downloadManager->download($download, function (int $current, int $total) use ($startAt, $progress, $output) {
                                 if ($total > 0) {
-                                    $progress->setMaxSteps($total);
-                                    $progress->setProgress($current);
+                                    $progress->setMaxSteps($total + ($startAt ?? 0));
+                                    $progress->setProgress($current + ($startAt ?? 0));
                                 }
                             }, $startAt, $timeout);
 


### PR DESCRIPTION
When resuming a download, currently only the remaining progress is used as the total file size, instead of the original.

Old resume:
![2024-09-04_00-00](https://github.com/user-attachments/assets/c06e568d-d252-4da0-a88d-0f6e1d8a772f)

New resume:
![2024-09-04_00-01](https://github.com/user-attachments/assets/20e23fc0-176c-41a2-bb6f-752d7453739d)